### PR TITLE
BaseTab class improvements

### DIFF
--- a/Editor/Plugins/SettingsWindow/BaseTab.cs
+++ b/Editor/Plugins/SettingsWindow/BaseTab.cs
@@ -5,11 +5,16 @@ namespace StansAssets.Foundation.Editor
 {
     public abstract class BaseTab : VisualElement
     {
+        protected readonly VisualElement m_Root;
+
         protected BaseTab(string uxmlPath)
         {
             // Import UXML
             var visualTree = AssetDatabase.LoadAssetAtPath<VisualTreeAsset>(uxmlPath);
-            Add(visualTree.CloneTree());
+            var template = visualTree.CloneTree();
+            m_Root = template[0];
+
+            Add(m_Root);
         }
     }
 }

--- a/Editor/Plugins/SettingsWindow/BaseTab.cs
+++ b/Editor/Plugins/SettingsWindow/BaseTab.cs
@@ -5,16 +5,11 @@ namespace StansAssets.Foundation.Editor
 {
     public abstract class BaseTab : VisualElement
     {
-        protected readonly VisualElement m_Root;
-
         protected BaseTab(string uxmlPath)
         {
             // Import UXML
             var visualTree = AssetDatabase.LoadAssetAtPath<VisualTreeAsset>(uxmlPath);
-            var template = visualTree.CloneTree();
-            m_Root = template[0];
-
-            Add(m_Root);
+            visualTree.CloneTree(this);
         }
     }
 }


### PR DESCRIPTION
added tab's root VisualElement instead of TemplateContainer & root VisualElement is cached to make it easily accessible in derived classes