### PR TITLE
BaseTab style flexGrow property fix

### DIFF
--- a/Editor/Plugins/SettingsWindow/BaseTab.cs
+++ b/Editor/Plugins/SettingsWindow/BaseTab.cs
@@ -17,6 +17,7 @@ namespace StansAssets.Foundation.Editor.Plugins
             // Import UXML
             var visualTree = AssetDatabase.LoadAssetAtPath<VisualTreeAsset>(uxmlPath);
             visualTree.CloneTree(this);
+            style.flexGrow = 1.0f;
         }
     }
 }


### PR DESCRIPTION
BaseTab flex grow property is set to 1.0, so all the children like ListView can grow