### PR TITLE
GetParentsOfType & GetFirstParentOfType extension methods

### DIFF
--- a/Runtime/UIElements/VisualElementExtension.cs
+++ b/Runtime/UIElements/VisualElementExtension.cs
@@ -1,4 +1,6 @@
-﻿using System.Reflection;
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
 using UnityEngine.UIElements;
 
 namespace StansAssets.Foundation.UIElements
@@ -31,6 +33,39 @@ namespace StansAssets.Foundation.UIElements
             var res= property?.GetMethod?.Invoke(visualElement, new object[] { });
             int intResult = (int?)res ?? -1;
             return (PseudoStates)intResult;
+        }
+
+        /// <summary>
+        /// Traverses up the hierarchy to find all of the parent instances of type T.
+        /// </summary>
+        /// <param name="element">Current element to search parents.</param>
+        /// <typeparam name="T">Type which you want to find</typeparam>
+        /// <returns>Collection of T instances found.</returns>
+        public static IEnumerable<T> GetParentsOfType<T>(this VisualElement element) where T : VisualElement
+        {
+            var result = new List<T>();
+
+            var parent = element;
+            while (parent != null)
+            {
+                if (parent is T selected)
+                    result.Add(selected);
+
+                parent = parent.parent;
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Traverses up the hierarchy to find first parent instance of type T.
+        /// </summary>
+        /// <param name="element">Current element to search parent.</param>
+        /// <typeparam name="T">Type which you want to find</typeparam>
+        /// <returns>T instance found</returns>
+        public static T GetFirstParentOfType<T>(this VisualElement element) where T : VisualElement
+        {
+            return GetParentsOfType<T>(element).FirstOrDefault();
         }
     }
 }


### PR DESCRIPTION
super handy GetParentsOfType & GetFirstParentOfType extension methods.
unfortunately, it's not possible to implement them as extensions for UQueryBuilder<T>.
but still, we have them as extensions for VisualElement class