### PR TITLE
fix: Compatibility to Unity 2018

### DIFF
--- a/Editor/Plugins/SettingsWindow/PackageSettingsWindow.cs
+++ b/Editor/Plugins/SettingsWindow/PackageSettingsWindow.cs
@@ -36,9 +36,9 @@ namespace StansAssets.Foundation.Editor.Plugins
             var visualTree = AssetDatabase.LoadAssetAtPath<VisualTreeAsset>(uxmlPath);
             var ussPath = $"{m_WindowUIFilesRootPath}/PackageSettingsWindow.uss";
             var stylesheet = AssetDatabase.LoadAssetAtPath<StyleSheet>(ussPath);
-            m_WindowRoot.styleSheets.Add(stylesheet);
             var template = visualTree.CloneTree();
             m_WindowRoot = template[0];
+            m_WindowRoot.styleSheets.Add(stylesheet);
             root.Add(m_WindowRoot);
 
             var packageInfo = GetPackageInfo();


### PR DESCRIPTION
## Purpose of this PR
<!-- Why do you submit this PR? -->
Fixed adding Style Sheet for PackageSettingsWindow

## Testing status
<!-- Remove the options that do not apply -->
* No tests have been added.

### Manual testing status
<!-- Describe how you tested your implementation/fix. Try to mention all the cases and flows.  -->
<!-- It will help the reviewer to understand if you missed any cases or test steps as well as will tell more about your feature or fix.   -->
Added unity 2019.3 to the new project - there are no errors or warnings when adding.
Added unity 2018.4 to the new project - there are no errors when adding.

## Comments to reviewers
<!-- Notes for the reviewers you have assigned.  Remove if not applicable-->
In Unity 2018.4 there is no “com.unity.test-framework” library, but when you add it, warnings appear that cannot be avoided
