### PR TITLE
fix: MainThreadDispatcher

### DIFF
--- a/Runtime/Async/MainThreadDispatcher/MainThreadDispatcher.cs
+++ b/Runtime/Async/MainThreadDispatcher/MainThreadDispatcher.cs
@@ -27,6 +27,8 @@ namespace StansAssets.Foundation.Async
                 s_MainThreadDispatcher = new MainThreadDispatcherEditor();
             else
                 s_MainThreadDispatcher = new MainThreadDispatcherRuntime();
+
+            s_MainThreadDispatcher.Init();
         }
 
         /// <summary>

--- a/Runtime/Async/MainThreadDispatcher/MainThreadDispatcherRuntime.cs
+++ b/Runtime/Async/MainThreadDispatcher/MainThreadDispatcherRuntime.cs
@@ -4,6 +4,7 @@ namespace StansAssets.Foundation.Async
     {
         public override void Init()
         {
+            MonoBehaviourCallback.Instantiate();
             MonoBehaviourCallback.OnUpdate += Update;
         }
     }


### PR DESCRIPTION
## Purpose of this PR
Initialization fixes for MainThreadDispatcher.

## Testing status
* No tests have been added.


### Manual testing status
Manually tested dispatcher on Android device to dispatch native callback into Unity main thread.

## Comments to reviewers
MainThreadDispatcher.Init() method should be called and MonoBehaviourCallback should be instantiated for runtime dispatcher to start getting EditorUpdate event.
