### PR TITLE
fix: Fix ButtonStrip class for Unity lower then 2019.2

### DIFF
--- a/Runtime/UIElements/Controls/ButtonStrip.cs
+++ b/Runtime/UIElements/Controls/ButtonStrip.cs
@@ -177,7 +177,11 @@ namespace StansAssets.Foundation.UIElements
                 else
                     button.AddToClassList(k_ButtonMidClassName);
 
+#if UNITY_2019_3_OR_NEWER
                 button.clicked += () =>
+#else
+                button.clickable.clicked  += () =>
+#endif
                 {
                     SetValue(choice);
                 };


### PR DESCRIPTION
## Purpose of this PR
Fix:
https://forum.unity.com/threads/released-ultimate-mobile-pro.571465/page-12#post-5998844

## Testing status
* No tests have been added.

### Manual testing status
No errors in the Editor anymore.

