### PR TITLE
ObjectPool.Find

### DIFF
--- a/Runtime/Patterns/Pooling/ObjectPool.cs
+++ b/Runtime/Patterns/Pooling/ObjectPool.cs
@@ -150,15 +150,16 @@ namespace StansAssets.Foundation.Patterns
             m_ActionOnGet?.Invoke(element);
             return element;
         }
-		
-		/// <summary>
-        /// Find an object in the pool.
+
+        /// <summary>
+        /// Try to get an object in the pool.
         /// </summary>
         /// <param name="pred">Search predicate.</param>
-        /// <returns>An existing object from the pool.</returns>
-        public T Find(Predicate<T> pred)
+        /// <param name="result">An existing object from the pool or <c>null</c> if the object is not found.</param>
+        /// <returns><c>true</c> if an appropriate object is found, <c>false</c> otherwise.</returns>
+        public bool TryGet(Predicate<T> pred, out T result)
         {
-            T result = null;
+            result = null;
             List<T> inappropriateElements = CollectionPool<List<T>, T>.Get();
             while (m_PoolStack.TryPop(out var element))
             {
@@ -179,9 +180,12 @@ namespace StansAssets.Foundation.Patterns
             CollectionPool<List<T>, T>.Release(inappropriateElements);
 
             if (result != null)
+            { 
                 m_ActionOnGet?.Invoke(result);
+                return true;
+            }
 
-            return result;
+            return false;
         }
 
         /// <summary>

--- a/Runtime/Patterns/Pooling/ObjectPool.cs
+++ b/Runtime/Patterns/Pooling/ObjectPool.cs
@@ -150,6 +150,39 @@ namespace StansAssets.Foundation.Patterns
             m_ActionOnGet?.Invoke(element);
             return element;
         }
+		
+		/// <summary>
+        /// Find an object in the pool.
+        /// </summary>
+        /// <param name="pred">Search predicate.</param>
+        /// <returns>An existing object from the pool.</returns>
+        public T Find(Predicate<T> pred)
+        {
+            T result = null;
+            List<T> inappropriateElements = CollectionPool<List<T>, T>.Get();
+            while (m_PoolStack.TryPop(out var element))
+            {
+                if (pred(element))
+                { 
+                    result = element;
+                    break;
+                }
+                else
+                {
+                    inappropriateElements.Add(element);
+                }
+            }
+
+            foreach (T element in inappropriateElements)
+                m_PoolStack.Push(element);
+
+            CollectionPool<List<T>, T>.Release(inappropriateElements);
+
+            if (result != null)
+                m_ActionOnGet?.Invoke(result);
+
+            return result;
+        }
 
         /// <summary>
         /// Get a new <see cref="PooledObject"/> which can be used to return the instance back to the pool when the PooledObject is disposed.


### PR DESCRIPTION
## Purpose of this PR
There are situations when it will be more profitable to find an existing configured item on the pool stack than to take the top one or create a new.

## Testing status
* No tests have been added.

### Manual testing status
Works great! Exactly what I need.
