### PR TITLE
fix: change Platform dependent compilation

### DIFF
--- a/Editor/Core/FoundationPackage.cs
+++ b/Editor/Core/FoundationPackage.cs
@@ -18,7 +18,7 @@ namespace StansAssets.Foundation.Editor
         public static readonly string RootPath = PackageManagerUtility.GetPackageRootPath(Name);
         
 
-#if UNITY_2019_4_OR_NEWER || UNITY_2020_2_OR_NEWER
+#if UNITY_2019_4_OR_NEWER
         /// <summary>
         /// Foundation package info.
         /// </summary>

--- a/Editor/EditorUtilities/PackageManagerUtility.cs
+++ b/Editor/EditorUtilities/PackageManagerUtility.cs
@@ -18,7 +18,7 @@ namespace StansAssets.Foundation.Editor
         /// </summary>
         public const string ManifestPath = "Packages/manifest.json";
 
-#if UNITY_2019_4_OR_NEWER || UNITY_2020_2_OR_NEWER
+#if UNITY_2019_4_OR_NEWER
         /// <summary>
         /// Returns PackageInfo if package is installed in the project, <c>null</c> otherwise.
         /// </summary>

--- a/Editor/EditorUtilities/UIToolkitEditorUtility.cs
+++ b/Editor/EditorUtilities/UIToolkitEditorUtility.cs
@@ -1,4 +1,4 @@
-#if UNITY_2019_4_OR_NEWER || UNITY_2020_2_OR_NEWER
+#if UNITY_2019_4_OR_NEWER
 using System;
 using UnityEditor;
 using UnityEngine;

--- a/Editor/UIToolkit/Controls/ButtonStrip/ButtonStrip.cs
+++ b/Editor/UIToolkit/Controls/ButtonStrip/ButtonStrip.cs
@@ -1,4 +1,4 @@
-#if UNITY_2019_4_OR_NEWER || UNITY_2020_2_OR_NEWER
+#if UNITY_2019_4_OR_NEWER
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/Editor/UIToolkit/Controls/HelpBox/HelpBox.cs
+++ b/Editor/UIToolkit/Controls/HelpBox/HelpBox.cs
@@ -1,4 +1,4 @@
-#if UNITY_2019_4_OR_NEWER || UNITY_2020_2_OR_NEWER
+#if UNITY_2019_4_OR_NEWER
 using JetBrains.Annotations;
 using UnityEditor;
 using UnityEngine.UIElements;

--- a/Editor/UIToolkit/Controls/Hyperlink/Hyperlink.cs
+++ b/Editor/UIToolkit/Controls/Hyperlink/Hyperlink.cs
@@ -1,4 +1,4 @@
-﻿#if UNITY_2019_4_OR_NEWER || UNITY_2020_2_OR_NEWER
+﻿#if UNITY_2019_4_OR_NEWER
 using JetBrains.Annotations;
 using StansAssets.Foundation.Editor;
 using UnityEngine;

--- a/Editor/UIToolkit/Controls/LoadingSpinner/LoadingSpinner.cs
+++ b/Editor/UIToolkit/Controls/LoadingSpinner/LoadingSpinner.cs
@@ -1,4 +1,4 @@
-﻿#if UNITY_2019_4_OR_NEWER || UNITY_2020_2_OR_NEWER
+﻿#if UNITY_2019_4_OR_NEWER
 using JetBrains.Annotations;
 using StansAssets.Foundation.Editor;
 using UnityEngine;

--- a/Editor/UIToolkit/Controls/SelectableLabel/SelectableLabel.cs
+++ b/Editor/UIToolkit/Controls/SelectableLabel/SelectableLabel.cs
@@ -1,4 +1,4 @@
-#if UNITY_2019_4_OR_NEWER || UNITY_2020_2_OR_NEWER
+#if UNITY_2019_4_OR_NEWER
 using JetBrains.Annotations;
 using StansAssets.Foundation.Editor;
 using UnityEngine.UIElements;

--- a/Editor/UIToolkit/Controls/SettingsBlock/SettingsBlock.cs
+++ b/Editor/UIToolkit/Controls/SettingsBlock/SettingsBlock.cs
@@ -1,5 +1,4 @@
-﻿#if UNITY_2019_4_OR_NEWER || UNITY_2020_2_OR_NEWER
-
+﻿#if UNITY_2019_4_OR_NEWER
 using JetBrains.Annotations;
 using StansAssets.Foundation.Editor;
 using UnityEngine.UIElements;

--- a/Runtime/UIToolkit/UIElementsUtility.cs
+++ b/Runtime/UIToolkit/UIElementsUtility.cs
@@ -1,4 +1,4 @@
-#if UNITY_2019_4_OR_NEWER || UNITY_2020_2_OR_NEWER
+#if UNITY_2019_4_OR_NEWER
 using System.Reflection;
 using UnityEngine;
 using UnityEngine.UIElements;

--- a/Runtime/UIToolkit/VisualElementExtension.cs
+++ b/Runtime/UIToolkit/VisualElementExtension.cs
@@ -1,4 +1,4 @@
-﻿#if UNITY_2019_4_OR_NEWER || UNITY_2020_2_OR_NEWER
+﻿#if UNITY_2019_4_OR_NEWER
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;


### PR DESCRIPTION
## Purpose of this PR
<!-- Why do you submit this PR? -->
Removed UNITY_2020_2_OR_NEWER to Platform dependent compilation
## Testing status
<!-- Remove the options that do not apply -->
* No tests have been added.


### Manual testing status
<!-- Describe how you tested your implementation/fix. Try to mention all the cases and flows.  -->
<!-- It will help the reviewer to understand if you missed any cases or test steps as well as will tell more about your feature or fix.   -->

## Comments to reviewers
<!-- Notes for the reviewers you have assigned.  Remove if not applicable-->
