### PR TITLE
feat: GetComponentInChildren from SceneExtension has optional includeInactive parameter

### DIFF
--- a/Runtime/Extensions/UnityEngine/SceneExtensions.cs
+++ b/Runtime/Extensions/UnityEngine/SceneExtensions.cs
@@ -12,13 +12,14 @@ namespace StansAssets.Foundation.Extensions
         /// A component is returned only if it is found on an active GameObject.
         /// </summary>
         /// <param name="scene">Scene to operate with.</param>
+        /// <param name="includeInactive">Should Components on inactive GameObjects be included in the found set?</param>
         /// <typeparam name="T">Type of the component.</typeparam>
         /// <returns>A component of the matching type, if found.</returns>
-        public static T GetComponentInChildren<T>(this Scene scene) where T : class
+        public static T GetComponentInChildren<T>(this Scene scene, bool includeInactive = false) where T : class
         {
             foreach (var gameObject in scene.GetRootGameObjects())
             {
-                var component = gameObject.GetComponentInChildren<T>();
+                var component = gameObject.GetComponentInChildren<T>(includeInactive);
                 if (component != null)
                 {
                     return component;


### PR DESCRIPTION
## Purpose of this PR
`GetComponentInChildren` from `SceneExtension` has optional `includeInactive` parameter.

## Testing status
* No tests have been added.

### Manual testing status
Checked with manual test-cases