### PR TITLE
feat: added method for texture to texture2D conversion

### DIFF
--- a/Runtime/Extensions/UnityEngine/TextureExtensions.cs
+++ b/Runtime/Extensions/UnityEngine/TextureExtensions.cs
@@ -16,16 +16,35 @@ namespace StansAssets.Foundation.Extensions
        
         public static Texture2D ToTexture2D(this Texture texture)
         {
-            if (texture is Texture2D) {
+            if (texture is Texture2D)
+            {
                 return texture as Texture2D;
             }
+
+            var nativePtr = texture.GetNativeTexturePtr();
+            if (nativePtr == null) // if a target platform doesn't support Native Ptr we go blitting the texture
+            {
+                Texture2D texture2D = new Texture2D(texture.width, texture.height, TextureFormat.RGBA32, false);
+                RenderTexture currentRT = RenderTexture.active;
+                RenderTexture renderTexture = RenderTexture.GetTemporary(texture.width, texture.height, 32);
+                Graphics.Blit(texture, renderTexture);
+
+                RenderTexture.active = renderTexture;
+                texture2D.ReadPixels(new Rect(0, 0, renderTexture.width, renderTexture.height), 0, 0);
+                texture2D.Apply();
+
+                RenderTexture.active = currentRT;
+                RenderTexture.ReleaseTemporary(renderTexture);
+                return texture2D;
+            }
+            
+            // otherwise GetNativeTexturePtr is used
             return Texture2D.CreateExternalTexture(
                 texture.width,
                 texture.height,
                 TextureFormat.RGB24,
                 false, false,
-                texture.GetNativeTexturePtr());
+                nativePtr);
         }
-
     }
 }

--- a/Runtime/Extensions/UnityEngine/TextureExtensions.cs
+++ b/Runtime/Extensions/UnityEngine/TextureExtensions.cs
@@ -1,0 +1,31 @@
+using System;
+using UnityEngine;
+
+namespace StansAssets.Foundation.Extensions
+{
+    /// <summary>
+    /// Unity `Texture` extension methods.
+    /// </summary>
+    public static class TextureExtensions
+    {
+        /// <summary>
+        /// Convert <see cref="Texture"/> to <see cref="Texture2D"/>.
+        /// </summary>
+        /// <param name="texture">Texture to convert.</param>
+        /// <returns>Converted texture as Texture2D</returns>
+       
+        public static Texture2D ToTexture2D(this Texture texture)
+        {
+            if (texture is Texture2D) {
+                return texture as Texture2D;
+            }
+            return Texture2D.CreateExternalTexture(
+                texture.width,
+                texture.height,
+                TextureFormat.RGB24,
+                false, false,
+                texture.GetNativeTexturePtr());
+        }
+
+    }
+}

--- a/Runtime/Extensions/UnityEngine/TextureExtensions.cs.meta
+++ b/Runtime/Extensions/UnityEngine/TextureExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c94045fb6cd9e9f409aa6707f7006fd4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Purpose of this PR
Often the Texture2D API is needed but texture represents the Texture class (or just Texture2D type is needed).

## Testing status
* No unit tests have been added.
* Performance tested in Editor, Win86 and Win64 builds using Stopwatch. 

### Manual testing status
Tested using Editor

## Comments to reviewers
It uses Native Ptr, so please check that in different builds (Android/iOS should work, but not tested). The API Refference for Native Ptr says the following:
"On platforms that do not support native code plug-ins, this function always returns NULL."
It's hard to say which platforms do so. In case of coming accross that issue, I know a slow but convenient solution with Blitting like here:
https://answers.unity.com/questions/1298366/rawimagetexture-to-texture2d.html

Native Ptr API ref:
https://docs.unity3d.com/ScriptReference/Texture.GetNativeTexturePtr.html
