### PR TITLE
chore: fix typos in comments for API Refference

### DIFF
--- a/Runtime/Extensions/UnityEngine/Vector3Extensions.cs
+++ b/Runtime/Extensions/UnityEngine/Vector3Extensions.cs
@@ -51,11 +51,11 @@ namespace StansAssets.Foundation.Extensions
         }
 
         /// <summary>
-        /// Smoothes a Vector3 that represents euler angles.
+        /// Smooths a Vector3 that represents euler angles.
         /// </summary>
         /// <param name="current">The current Vector3 value.</param>
         /// <param name="target">The target Vector3 value.</param>
-        /// <param name="velocity">A refernce Vector3 used internally.</param>
+        /// <param name="velocity">A reference Vector3 used internally.</param>
         /// <param name="smoothTime">The time to smooth, in seconds.</param>
         /// <returns>The smoothed Vector3 value.</returns>
         public static Vector3 SmoothDampEuler(this in Vector3 current, Vector3 target, ref Vector3 velocity, float smoothTime)

--- a/Runtime/Patterns/Singleton/MonoSingleton.cs
+++ b/Runtime/Patterns/Singleton/MonoSingleton.cs
@@ -5,7 +5,7 @@ namespace StansAssets.Foundation.Patterns
     /// <summary>
     /// Singleton pattern implementation.
     /// Can be used with classes extended from a MonoBehaviour.
-    /// Once instance is found or created, game object will be marked as DontDestroyOnLoadю
+    /// Once instance is found or created, game object will be marked as DontDestroyOnLoad.
     /// </summary>
     public abstract class MonoSingleton<T> : MonoBehaviour where T : MonoBehaviour
     {

--- a/Runtime/Utilities/MiniJSON.cs
+++ b/Runtime/Utilities/MiniJSON.cs
@@ -41,7 +41,7 @@ namespace StansAssets.Foundation
     /// This class encodes and decodes JSON strings.
     /// Spec. details, see http://www.json.org/
     ///
-    /// JSON uses Arrays and Objects. These corOnerespond here to the datatypes IList and IDictionary.
+    /// JSON uses Arrays and Objects. These correspond here to the datatypes IList and IDictionary.
     /// All numbers are parsed to doubles.
     /// </summary>
     public static class Json {


### PR DESCRIPTION
## Purpose of this PR
I've found numbers of misspelling, typos and grammar mistakes in our API Refference docs. This 'issue' is backlogged actualy and I try to find some auto-correction utility. In this PR only results of Rider Spelling Inspection, which checks typos only.

## Testing status
No need but I've launched unit test with success for sure

### Manual testing status
Nothing to test
