### PR TITLE
feat: extended 'FindImplementationsOf'

### DIFF
--- a/Runtime/Extensions/CSharp/TypeExtensions.cs
+++ b/Runtime/Extensions/CSharp/TypeExtensions.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace StansAssets.Foundation.Extensions
+{
+    /// <summary>
+    /// CSharp <see cref="Type"/> extension methods.
+    /// </summary>
+    public static class TypeExtensions
+    {
+        /// <summary>
+        /// Performs a check if <c>Type</c> can be instanced using default constructor 
+        /// </summary>
+        /// <param name="type">A <c>Type</c> to check</param>
+        /// <returns>Returns <c>true</c> if type can be instanced and <c>false</c> otherwise</returns>
+        public static bool CanCreateInstanceUsingDefaultConstructor(this Type type)
+        {
+            return type.IsValueType || !type.IsAbstract && type.GetConstructor(Type.EmptyTypes) != null;
+        }
+    }
+}

--- a/Runtime/Extensions/CSharp/TypeExtensions.cs.meta
+++ b/Runtime/Extensions/CSharp/TypeExtensions.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: b398886394f447d6b0a2e3e087fd78b3
+timeCreated: 1642761393

--- a/Runtime/Utilities/ReflectionUtility.cs
+++ b/Runtime/Utilities/ReflectionUtility.cs
@@ -112,7 +112,7 @@ namespace StansAssets.Foundation
         }
 
         /// <summary>
-        /// Find all method custom attributes of the type <c>T</c>.
+        /// Find all methods with custom attribute of type <c>T</c>.
         /// </summary>
         /// <param name="methodBindingFlags">Method binding Attributes. ` BindingFlags.Instance | BindingFlags.Public` by default.</param>
         /// <param name="inherit"><c>true</c> to search in the member's inheritance chain to find the attributes</param>


### PR DESCRIPTION
## Purpose of this PR
Some times we need to find all implementations of interfaces provided by Unity team. We need to find only custom implementations ignoring built-In ones. In this pull-request 'FindImplementationsOf' method is extended to ignore 'UnityEngine', 'UnityEditor', 'Unity.' and 'System' assemblies

## Testing status
* No tests have been added.

### Manual testing status
Tested manually is scope of com.stansassets.build project
