### PR TITLE
fix: Virtualized Update method for MainThreadDispatcher

### DIFF
--- a/Runtime/Async/MainThreadDispatcher/MainThreadDispatcherBase.cs
+++ b/Runtime/Async/MainThreadDispatcher/MainThreadDispatcherBase.cs
@@ -10,8 +10,8 @@ namespace StansAssets.Foundation.Async
         public abstract void Init();
 
         public void Enqueue(Action action) => s_ExecutionQueue.Enqueue(action);
-
-        protected void Update()
+        //TODO: Implement generic update methid like generic implementation : MainThreadDispatcher<T> where T : IDispatcherUpdate
+        protected virtual void Update()
         {
             if(s_ExecutionQueue.TryDequeue(out var action))
                 action.Invoke();


### PR DESCRIPTION
## Purpose of this PR
Got feedback that developer wants some different logic in MainThreadDispatcherBase.Update, so instead of duing exact thing - we give him virtuality to adjust any logic.

## Comments to reviewers
Added TODO to think in bg: 
Implement generic update methid like generic implementation : MainThreadDispatcher<T> where T : IDispatcherUpdate
