### PR TITLE
fix: YieldPool Unity 2019 compilation fixed.

### DIFF
--- a/Runtime/Async/Coroutine/Pooled YieldInstruction/WaitForSecondsPooled.cs
+++ b/Runtime/Async/Coroutine/Pooled YieldInstruction/WaitForSecondsPooled.cs
@@ -1,3 +1,4 @@
+#if UNITY_2020_1_OR_NEWER
 using UnityEngine;
 
 namespace StansAssets.Foundation.Async
@@ -34,3 +35,4 @@ namespace StansAssets.Foundation.Async
         }
     }
 }
+#endif

--- a/Runtime/Async/Coroutine/Pooled YieldInstruction/WaitForSecondsRealtimePooled.cs
+++ b/Runtime/Async/Coroutine/Pooled YieldInstruction/WaitForSecondsRealtimePooled.cs
@@ -1,3 +1,4 @@
+#if UNITY_2020_1_OR_NEWER
 using UnityEngine;
 
 namespace StansAssets.Foundation.Async
@@ -34,3 +35,4 @@ namespace StansAssets.Foundation.Async
         }
     }
 }
+#endif

--- a/Runtime/Async/Coroutine/Pooled YieldInstruction/YieldPool.cs
+++ b/Runtime/Async/Coroutine/Pooled YieldInstruction/YieldPool.cs
@@ -12,10 +12,13 @@ namespace StansAssets.Foundation.Async
         static YieldPool()
         {
             s_Instructions = new Dictionary<Type, ObjectPool<PooledYieldInstruction>>();
-            Add<WaitForSecondsPooled>();
+            
             Add<WaitUntilPooled>();
             Add<WaitWhilePooled>();
+#if UNITY_2020_1_OR_NEWER
+            Add<WaitForSecondsPooled>();
             Add<WaitForSecondsRealtimePooled>();
+#endif
         }
 
         static void Add<T>() where T : PooledYieldInstruction, new()
@@ -34,6 +37,7 @@ namespace StansAssets.Foundation.Async
             return (T)s_Instructions[typeof(T)].Get();
         }
 
+#if UNITY_2020_1_OR_NEWER
         /// <summary>
         ///     Wait for a given number of seconds using scaled time.
         ///     <param name="seconds">Delay execution by the amount of time in seconds.</param>
@@ -51,6 +55,7 @@ namespace StansAssets.Foundation.Async
         {
             return GetFromPool<WaitForSecondsRealtimePooled>().Wait(seconds);
         }
+#endif
 
         /// <summary>
         ///     Suspends the coroutine execution until the supplied delegate evaluates to false.


### PR DESCRIPTION

## Purpose of this PR
Fix compilation error in YieldPool when the package is used with Unity 2019.

## Testing status
* No tests have been added.

### Manual testing status
Tested in Unity 2019.4. 

