### PR TITLE
fix: MonoSingleton and MonoBehaviourCallback improvements

### DIFF
--- a/Runtime/Async/Coroutine/MonoBehaviourCallback.cs
+++ b/Runtime/Async/Coroutine/MonoBehaviourCallback.cs
@@ -12,12 +12,12 @@ namespace StansAssets.Foundation.Async
     /// </summary>
     public class MonoBehaviourCallback : MonoSingleton<MonoBehaviourCallback>
     {
-        event Action m_OnUpdate;
-        event Action m_OnLateUpdate;
-        event Action m_OnFixedUpdate;
-        event Action m_OnApplicationQuit;
-        event Action<bool> m_ApplicationOnPause;
-        event Action<bool> m_OnApplicationFocus;
+        event Action m_OnUpdate = delegate { };
+        event Action m_OnLateUpdate = delegate { };
+        event Action m_OnFixedUpdate = delegate { };
+        event Action m_OnApplicationQuit = delegate { };
+        event Action<bool> m_ApplicationOnPause = delegate { };
+        event Action<bool> m_OnApplicationFocus = delegate { };
         
         /// <summary>
         /// Update is called every frame.
@@ -80,16 +80,16 @@ namespace StansAssets.Foundation.Async
             remove => Instance.m_OnApplicationFocus -= value;
         }
 
-        void Update() => m_OnUpdate?.Invoke();
-        void LateUpdate() => m_OnLateUpdate?.Invoke();
-        void FixedUpdate() => m_OnFixedUpdate?.Invoke();
-        void OnApplicationPause(bool pauseStatus) => m_ApplicationOnPause?.Invoke(pauseStatus);
-        void OnApplicationFocus(bool hasFocus) => m_OnApplicationFocus?.Invoke(hasFocus);
+        void Update() => m_OnUpdate.Invoke();
+        void LateUpdate() => m_OnLateUpdate.Invoke();
+        void FixedUpdate() => m_OnFixedUpdate.Invoke();
+        void OnApplicationPause(bool pauseStatus) => m_ApplicationOnPause.Invoke(pauseStatus);
+        void OnApplicationFocus(bool hasFocus) => m_OnApplicationFocus.Invoke(hasFocus);
 
         protected override void OnApplicationQuit()
         {
             base.OnApplicationQuit();
-            m_OnApplicationQuit?.Invoke();
+            m_OnApplicationQuit.Invoke();
         }
     }
 }

--- a/Runtime/Async/Coroutine/MonoBehaviourCallback.cs
+++ b/Runtime/Async/Coroutine/MonoBehaviourCallback.cs
@@ -12,53 +12,84 @@ namespace StansAssets.Foundation.Async
     /// </summary>
     public class MonoBehaviourCallback : MonoSingleton<MonoBehaviourCallback>
     {
+        event Action m_OnUpdate;
+        event Action m_OnLateUpdate;
+        event Action m_OnFixedUpdate;
+        event Action m_OnApplicationQuit;
+        event Action<bool> m_ApplicationOnPause;
+        event Action<bool> m_OnApplicationFocus;
+        
         /// <summary>
         /// Update is called every frame.
         /// Learn more: [MonoBehaviour.Update](https://docs.unity3d.com/ScriptReference/MonoBehaviour.Update.html)
         /// </summary>
-        public static event Action OnUpdate;
+        public static event Action OnUpdate
+        {
+            add => Instance.m_OnUpdate += value;
+            remove => Instance.m_OnUpdate -= value;
+        }
 
         /// <summary>
         /// LateUpdate is called after all Update functions have been called. This is useful to order script execution.
         /// For example a follow camera should always be implemented in LateUpdate because it tracks objects that might have moved inside Update.
         /// Learn more: [MonoBehaviour.LateUpdate](https://docs.unity3d.com/ScriptReference/MonoBehaviour.LateUpdate.html)
         /// </summary>
-        public static event Action OnLateUpdate;
+        public static event Action OnLateUpdate
+        {
+            add => Instance.m_OnLateUpdate += value;
+            remove => Instance.m_OnLateUpdate -= value;
+        }
+        
+        /// <summary>
+        /// Frame-rate independent MonoBehaviour.FixedUpdate message for physics calculations.
+        /// Learn more: [MonoBehaviour.FixedUpdate](https://docs.unity3d.com/ScriptReference/MonoBehaviour.FixedUpdate.html)
+        /// </summary>
+        public static event Action OnFixedUpdate
+        {
+            add => Instance.m_OnFixedUpdate += value;
+            remove => Instance.m_OnFixedUpdate -= value;
+        }
         
         /// <summary>
         /// In the editor this is called when the user stops playmode.
         /// Learn more: [MonoBehaviour.OnApplicationQuit](https://docs.unity3d.com/ScriptReference/MonoBehaviour.OnApplicationQuit.html)
         /// </summary>
-        public static event Action ApplicationOnQuit;
+        public static event Action ApplicationOnQuit
+        {
+            add => Instance.m_OnApplicationQuit += value;
+            remove => Instance.m_OnApplicationQuit -= value;
+        }
         
         /// <summary>
         /// Sent to all GameObjects when the application pauses.
         /// Learn more: [MonoBehaviour.OnApplicationPause](https://docs.unity3d.com/ScriptReference/MonoBehaviour.OnApplicationPause.html)
         /// </summary>
-        public static event Action<bool> ApplicationOnPause;
+        public static event Action<bool> ApplicationOnPause
+        {
+            add => Instance.m_ApplicationOnPause += value;
+            remove => Instance.m_ApplicationOnPause -= value;
+        }
         
         /// <summary>
         /// Sent to all GameObjects when the player gets or loses focus.
         /// Learn more: [MonoBehaviour.OnApplicationFocus](https://docs.unity3d.com/ScriptReference/MonoBehaviour.OnApplicationFocus.html)
         /// </summary>
-        public static event Action<bool> ApplicationOnFocus;
+        public static event Action<bool> ApplicationOnFocus
+        {
+            add => Instance.m_OnApplicationFocus += value;
+            remove => Instance.m_OnApplicationFocus -= value;
+        }
 
-        /// <summary>
-        /// Frame-rate independent MonoBehaviour.FixedUpdate message for physics calculations.
-        /// Learn more: [MonoBehaviour.FixedUpdate](https://docs.unity3d.com/ScriptReference/MonoBehaviour.FixedUpdate.html)
-        /// </summary>
-        public static event Action OnFixedUpdate;
-
-        void Update() => OnUpdate?.Invoke();
-        void LateUpdate() => OnLateUpdate?.Invoke();
-        void FixedUpdate() => OnFixedUpdate?.Invoke();
-        void OnApplicationPause(bool pauseStatus) => ApplicationOnPause?.Invoke(pauseStatus);
-        void OnApplicationFocus(bool hasFocus) => ApplicationOnFocus?.Invoke(hasFocus);
+        void Update() => m_OnUpdate?.Invoke();
+        void LateUpdate() => m_OnLateUpdate?.Invoke();
+        void FixedUpdate() => m_OnFixedUpdate?.Invoke();
+        void OnApplicationPause(bool pauseStatus) => m_ApplicationOnPause?.Invoke(pauseStatus);
+        void OnApplicationFocus(bool hasFocus) => m_OnApplicationFocus?.Invoke(hasFocus);
 
         protected override void OnApplicationQuit()
         {
             base.OnApplicationQuit();
-            ApplicationOnQuit?.Invoke();
+            m_OnApplicationQuit?.Invoke();
         }
     }
 }

--- a/Runtime/Async/MainThreadDispatcher/MainThreadDispatcherRuntime.cs
+++ b/Runtime/Async/MainThreadDispatcher/MainThreadDispatcherRuntime.cs
@@ -4,7 +4,6 @@ namespace StansAssets.Foundation.Async
     {
         public override void Init()
         {
-            MonoBehaviourCallback.Instantiate();
             MonoBehaviourCallback.OnUpdate += Update;
         }
     }

--- a/Runtime/Patterns/Singleton/MonoSingleton.cs
+++ b/Runtime/Patterns/Singleton/MonoSingleton.cs
@@ -57,6 +57,12 @@ namespace StansAssets.Foundation.Patterns
         /// </summary>
         public static void Instantiate()
         {
+            if (HasInstance)
+            {
+                Debug.LogWarning($"You are trying to Instantiate {typeof(T).FullName}, but it already has an Instance. Please use Instance property instead.");
+                return;
+            }
+            
             var name = typeof(T).FullName;
             s_Instance = new GameObject(name).AddComponent<T>();
         }

--- a/Runtime/Patterns/Singleton/MonoSingleton.cs
+++ b/Runtime/Patterns/Singleton/MonoSingleton.cs
@@ -55,7 +55,7 @@ namespace StansAssets.Foundation.Patterns
         /// But it may be useful if you want manually control when the instance is created,
         /// even if you do not this specific instance at the moment
         /// </summary>
-        public static void Instantiate()
+        static void Instantiate()
         {
             if (HasInstance)
             {

--- a/Tests/Editor/Patterns/MonoSingletonTests.cs
+++ b/Tests/Editor/Patterns/MonoSingletonTests.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using NUnit.Framework;
+using StansAssets.Foundation.Patterns;
+
+namespace StansAssets.Foundation.Tests.Patterns
+{
+    class TestSingleton : MonoSingleton<TestSingleton>
+    {
+        public readonly string Id;
+
+        public TestSingleton()
+        {
+            Id = Guid.NewGuid().ToString();
+        }
+    }
+
+    public class MonoSingletonTests
+    {
+        [Test]
+        public void SingleInstanceTest()
+        {
+            var a = TestSingleton.Instance;
+            var b = TestSingleton.Instance;
+            var c = TestSingleton.Instance;
+            Assert.IsTrue(a.Id.Equals(b.Id) && b.Id.Equals(c.Id));
+        }
+    }
+}

--- a/Tests/Editor/Patterns/MonoSingletonTests.cs.meta
+++ b/Tests/Editor/Patterns/MonoSingletonTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d5f243970afe28b47ba76edfe8607ae6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.stansassets.foundation",
   "displayName": "Stans Assets - Foundation",
-  "version": "1.0.27",
+  "version": "2.0.0",
   "unity": "2018.4",
   "description": "Foundation package is a collection of utility methods, design patterns, and extensions for Unity.",
   "keywords": [


### PR DESCRIPTION
## Purpose of this PR
In one of my projects I noticed double Monobehaviour.OnUpdate event firing per frame, I've started my investigation and noticed an issue.

## Testing status
* No tests have been added.

### Manual testing status
Used this script to test fixes:
```C
class MonobehaviourCallbackTests : MonoBehaviour
{
    float m_LastTimestamp;

    void Awake()
    {
        MonoBehaviourCallback.Instantiate();
        MonoBehaviourCallback.Instantiate();
        MonoBehaviourCallback.Instantiate();
    }

    void OnEnable()
    {
        MonoBehaviourCallback.OnUpdate += MonoBehaviourCallback_Update;
    }
    
    void OnDisable()
    {
        MonoBehaviourCallback.OnUpdate -= MonoBehaviourCallback_Update;
    }

    void MonoBehaviourCallback_Update()
    {
        var currentTimestamp = Time.realtimeSinceStartup;
        Debug.Log($"Update current: {currentTimestamp:F3}, last: {m_LastTimestamp:F3}, deltaTime: {currentTimestamp-m_LastTimestamp:F3}, Time.deltaTime: {Time.deltaTime:F3}");
        m_LastTimestamp = currentTimestamp;
    }
}
```
![image](https://github.com/StansAssets/com.stansassets.foundation/assets/66057791/180335c7-7ff5-450b-b492-cbf27aa67cf6)

## Comments to reviewers
The problem was that MonoSingleton class has unrestricted access to [public Instantiate method](https://github.com/StansAssets/com.stansassets.foundation/blob/99a71f5da03f60e5cd14188db04c1466a8c5b785/Runtime/Patterns/Singleton/MonoSingleton.cs#L58), so it's available to Instantiate same MonoBehaviour many times (but I expect to have it as Singleton).
```C
        // Method that might be accidentally called multiple times and cause unexpected results
        public static void Instantiate()
        {
            var name = typeof(T).FullName;
            s_Instance = new GameObject(name).AddComponent<T>();
        }
```
```C
        // Replaced with this implementation
        public static void Instantiate()
        {
            if (HasInstance)
            {
                Debug.LogWarning($"You are trying to Instantiate {typeof(T).FullName}, but it already has an Instance. Please use Instance property instead.");
                return;
            }
            
            var name = typeof(T).FullName;
            s_Instance = new GameObject(name).AddComponent<T>();
        }
```
